### PR TITLE
Add accessor for featured image (post thumbnail) sizes

### DIFF
--- a/src/ThumbnailMeta.php
+++ b/src/ThumbnailMeta.php
@@ -4,6 +4,11 @@ namespace Corcel;
 
 class ThumbnailMeta extends PostMeta
 {
+    const SIZE_THUMBNAIL = 'thumbnail';
+    const SIZE_MEDIUM    = 'medium';
+    const SIZE_LARGE     = 'large';
+    const SIZE_FULL      = 'full';
+
     protected $with = ['attachment'];
 
     public function attachment()
@@ -14,5 +19,22 @@ class ThumbnailMeta extends PostMeta
     public function __toString()
     {
         return $this->attachment->guid;
+    }
+
+    public function size($size)
+    {
+        if ($size  == self::SIZE_FULL) {
+            return $this->attachment->url;
+        }
+
+        $sizes = $this->attachment->meta->_wp_attachment_metadata['sizes'];
+
+        if (! isset($sizes[$size])) {
+            throw new \Exception('Invalid size: ' . $size);
+        }
+
+        return dirname($this->attachment->url)
+            . '/'
+            . $sizes[$size]['file'];
     }
 }


### PR DESCRIPTION
I'm very unfamiliar with WP, but this appears to work.
Allows ability to get different thumbnail sizes ala `the_post_thumbnail` [ref](https://developer.wordpress.org/reference/functions/the_post_thumbnail/)

I see this mentioned in #184 but the solution was not clear to me.

```php
use Corcel\ThumbnailMeta;

if ($article->thumbnail) {
    echo $helper->img(
        $article->thumbnail->size(ThumbnailMeta::SIZE_THUMBNAIL),
        [
            'alt' => $article->thumbnail->attachment->alt,
            'id'  => 'image_' . $article->thumbnail->value
        ]
    );
}
```
(`$helper` is just an example using [Aura\Html Image Helper](https://github.com/auraphp/Aura.Html/blob/2.x/README-HELPERS.md#img))