### PR TITLE
Add relationship for Page children

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -143,6 +143,16 @@ class Post extends Model
         return $this->belongsTo('Corcel\Post', 'post_parent');
     }
 
+    /*
+     * Post Children
+     *
+     * @return Illuminate\Database\Eloquent\Collection
+     */
+    public function children()
+    {
+        return $this->hasMany(__CLASS__, 'post_parent', 'ID');
+    }
+
     /**
      * Get attachment.
      *


### PR DESCRIPTION
I see a relationship on the  `Post` object for getting at the `parent`, but I did not see a way for getting children. I also might be confused cuz in WP, I dont see the relevance of parent/child in the post admin. only page.