### PR TITLE
Let Options model extends Model instead of Eloquent

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -3,14 +3,13 @@
 namespace Corcel;
 
 use Exception;
-use Illuminate\Database\Eloquent\Model as Eloquent;
 
 /**
  * Options class.
  *
  * @author José CI <josec89@gmail.com>
  */
-class Options extends Eloquent
+class Options extends Model
 {
     const CREATED_AT = null;
     const UPDATED_AT = null;

--- a/tests/PostTest.php
+++ b/tests/PostTest.php
@@ -119,7 +119,8 @@ class PostTest extends PHPUnit_Framework_TestCase
         $taxonomy = $post->taxonomies()->first();
         $this->assertEquals($taxonomy->taxonomy, 'category');
 
-        $post = Post::taxonomy('category', 'php')->first();
+		//	Test taxonomies with an array of terms 
+        $post = Post::taxonomy('category', ['php'])->first();
         $this->assertEquals($post->ID, 1);
 
         $post = Post::taxonomy('category', 'php')->first();

--- a/tests/PostTest.php
+++ b/tests/PostTest.php
@@ -119,7 +119,6 @@ class PostTest extends PHPUnit_Framework_TestCase
         $taxonomy = $post->taxonomies()->first();
         $this->assertEquals($taxonomy->taxonomy, 'category');
 
-		//	Test taxonomies with an array of terms 
         $post = Post::taxonomy('category', ['php'])->first();
         $this->assertEquals($post->ID, 1);
 


### PR DESCRIPTION
By extending directly Eloquent, not in all cases the correct database connection will picked. 

It looks like extending Corcel\Models gives no issues.