### PR TITLE
Fixed fatal error in Laravel without publishing config

### DIFF
--- a/src/Traits/ShortcodesTrait.php
+++ b/src/Traits/ShortcodesTrait.php
@@ -72,7 +72,7 @@ trait ShortcodesTrait
     private function parseConfigShortcodes(ShortcodeFacade $facade)
     {
         if (Corcel::isLaravel()) {
-            $shortcodes = config('corcel.shortcodes');
+            $shortcodes = config('corcel.shortcodes', []);
             foreach ($shortcodes as $tag => $class) {
                 $facade->addHandler($tag, [new $class, 'render']);
             }


### PR DESCRIPTION
If we not publish config file Laravel tries to iterate over null. This is causing fatal error: `Invalid argument supplied for foreach()`