### PR TITLE
#306 fix - Return full size attachment instead of throwing exception for unknown size

### DIFF
--- a/src/Model/Meta/ThumbnailMeta.php
+++ b/src/Model/Meta/ThumbnailMeta.php
@@ -46,7 +46,7 @@ class ThumbnailMeta extends PostMeta
         $sizes = Arr::get($meta, 'sizes');
 
         if (!isset($sizes[$size])) {
-            throw new \Exception('Invalid size: ' . $size);
+            return $this->attachment->url;
         }
 
         $data = Arr::get($sizes, $size);

--- a/tests/Unit/Model/ThumbnailTest.php
+++ b/tests/Unit/Model/ThumbnailTest.php
@@ -73,6 +73,19 @@ class ThumbnailTest extends \Corcel\Tests\TestCase
     }
 
     /**
+     * @test
+     */
+    public function it_returns_full_size_for_unknown_size()
+    {
+        $meta = $this->createThumbnailMetaWithAttachment();
+
+        $full_size = $meta->size(ThumbnailMeta::SIZE_FULL);
+        $unknown_size = $meta->size('unknown');
+
+        $this->assertEquals($full_size, $unknown_size);
+    }
+
+    /**
      * @return ThumbnailMeta
      */
     private function createThumbnailMetaWithAttachment()

--- a/tests/Unit/Model/ThumbnailTest.php
+++ b/tests/Unit/Model/ThumbnailTest.php
@@ -79,10 +79,10 @@ class ThumbnailTest extends \Corcel\Tests\TestCase
     {
         $meta = $this->createThumbnailMetaWithAttachment();
 
-        $full_size = $meta->size(ThumbnailMeta::SIZE_FULL);
-        $unknown_size = $meta->size('unknown');
+        $fullSize = $meta->size(ThumbnailMeta::SIZE_FULL);
+        $unknownSize = $meta->size('unknown');
 
-        $this->assertEquals($full_size, $unknown_size);
+        $this->assertEquals($fullSize, $unknownSize);
     }
 
     /**


### PR DESCRIPTION
Fixes #306 