### PR TITLE
Removed unnecesary toArray in Attachment model

### DIFF
--- a/src/Model/Attachment.php
+++ b/src/Model/Attachment.php
@@ -43,14 +43,4 @@ class Attachment extends Post
         'caption' => 'post_excerpt',
         'alt' => ['meta' => '_wp_attachment_image_alt'],
     ];
-
-    /**
-     * @return array
-     */
-    public function toArray()
-    {
-        return collect($this->appends)->map(function ($field) {
-            return [$field => $this->getAttribute($field)];
-        })->collapse()->toArray();
-    }
 }


### PR DESCRIPTION
Because of #305 we can safely remove `toArray` method from Attachment model