### PR TITLE
Fix post type nesting

### DIFF
--- a/src/Model/Post.php
+++ b/src/Model/Post.php
@@ -160,11 +160,17 @@ class Post extends Model
      */
     public function newEloquentBuilder($query)
     {
-        $builder = new PostBuilder($query);
+        return new PostBuilder($query);
+    }
 
+    /**
+     * @return PostBuilder
+     */
+    public function newQuery()
+    {
         return $this->postType ?
-            $builder->type($this->postType) :
-            $builder;
+            parent::newQuery()->type($this->postType) :
+            parent::newQuery();
     }
 
     /**

--- a/tests/Unit/Model/PostTest.php
+++ b/tests/Unit/Model/PostTest.php
@@ -563,6 +563,22 @@ class PostTest extends \Corcel\Tests\TestCase
     }
 
     /**
+     * @test
+     */
+    public function it_has_correct_post_type_with_callback_in_where()
+    {
+        $query = Page::where(function($q) {
+            $q->where('foo', 'bar');
+        });
+
+        $expectedQuery = 'select * from "wp_posts" where "post_type" = ? and ("foo" = ?)';
+        $expectedBindings = ['page', 'bar'];
+
+        $this->assertEquals($expectedQuery, $query->toSql());
+        $this->assertSame($expectedBindings, $query->getBindings());
+    }
+
+    /**
      *
      * @return Post
      */

--- a/tests/Unit/Model/PostTest.php
+++ b/tests/Unit/Model/PostTest.php
@@ -567,7 +567,7 @@ class PostTest extends \Corcel\Tests\TestCase
      */
     public function it_has_correct_post_type_with_callback_in_where()
     {
-        $query = Page::where(function($q) {
+        $query = Page::where(function ($q) {
             $q->where('foo', 'bar');
         });
 


### PR DESCRIPTION
Fixes #326. Now only new instances of Builder will have `post_type` where clause.